### PR TITLE
hotfix: updated reports logic

### DIFF
--- a/api/src/product/product.service.ts
+++ b/api/src/product/product.service.ts
@@ -75,7 +75,9 @@ export class ProductService {
 
     async priceDateRangeReport(productPriceDate: ProductReportQueryDTO): Promise<PriceDateItemDTO> {
         try {
-            const totalCount = (await this.productModel.find()).length;
+            const totalCount = (await this.productModel.find(
+                { "isDeleted": false }
+            )).length;
             const match: PipelineStage = {
                 "$match": {
                     "$and": [
@@ -104,7 +106,9 @@ export class ProductService {
 
     async brandReport(brand: string) {
         try {
-            const totalCount = (await this.productModel.find()).length;
+            const totalCount = (await this.productModel.find(
+                { "isDeleted": false }
+            )).length;
             const match: PipelineStage = {
                 "$match": {
                     "$and": [


### PR DESCRIPTION
HOTFIX
updated reports logic

HOW
- the calculated total for percentages was using the full collection and not just the non-deleted products
- fixed it so now we use the correct total